### PR TITLE
Fix README references

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ lib/
 ├ shared/                   # Cross-feature UI & helpers
 │ ├ components/             # custom_button, custom_text_field
 │ ├ providers/              # app_settings_provider, localization_provider, theme_provider
-│ └ widgets/                # loading_overlay, error_view, spacing_box
+│ └ widgets/                # responsive_wrapper, spacing_box
 
 └ features/                 # Vertical slices / domains
   ├ splash/                # splash_screen.dart
   ├ auth/                  # auth_repository, AuthProvider, login_screen
-  ├ home/                  # HomeProvider, home_screen
+  ├ home/                  # home_screen
   └ …                      # add more (cart, profile, orders, etc.)
 ```
 


### PR DESCRIPTION
## Summary
- replace removed widgets from folder structure section
- remove reference to HomeProvider

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455676baec832d87ae08bde9d1eeb1